### PR TITLE
Raise AdapterInputError rather than NotImplementedError if propagate_…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [unreleased]
 
+### Changed
+
+- `adapter.collect_wfn()` now raises `AdapterInputError` rather than `NotImplementedError` if `propagate_wfn=True` is passed. This change allows these errors to be captured by the `except QCOPBaseError as e:` block in `adapter.compute()` so that the `ProgramFailure` object can be returned to the user. This fixes a 500 error in ChemCloud Server when a user passes `propagate_wfn=True` to a program that doesn't support it.
+
 ## [0.4.5] - 2023-09-19
 
 ### Added

--- a/qcop/adapters/base.py
+++ b/qcop/adapters/base.py
@@ -98,8 +98,9 @@ class BaseAdapter(ABC):
             propagate_wfn: For any adapter performing a sequential task, such
                 as a geometry optimization, propagate the wavefunction from the previous
                 step to the next step. This is useful for accelerating convergence by
-                using a previously computed wavefunction as a starting guess. This will
-                be ignored if the adapter does not support it.
+                using a previously computed wavefunction as a starting guess. If an
+                adapter does not support wavefunction propagation, an AdapterInputError
+                will be raised.
             **kwargs: Additional keyword arguments to pass to the adapter or
                 qcng.compute().
 
@@ -217,8 +218,9 @@ class BaseAdapter(ABC):
 
         """
         # Collect wavefunction file from the calc_dir
-        raise NotImplementedError(
-            f"Adapter for {self.program} does not support wavefunction collection."
+        raise AdapterInputError(
+            self.program,
+            f"Adapter for {self.program} does not support wavefunction collection.",
         )
 
 

--- a/tests/test_base_adapters.py
+++ b/tests/test_base_adapters.py
@@ -169,3 +169,9 @@ def test_stdout_collected_with_failed_execution(
     assert excinfo.value.stdout == "some stdout"
     # Added to ProgramFailure
     assert excinfo.value.program_failure.stdout == "some stdout"
+
+
+def test_collect_wfn_raises_adapter_input_error_if_not_implemented(test_adapter):
+    """Test that collect_wfn raises an AdapterInputError if not implemented."""
+    with pytest.raises(AdapterInputError):
+        test_adapter.collect_wfn(None)


### PR DESCRIPTION
…wfn=True passed to an adapter that does not support it. Fixes a 500 server error in ChemCloud Server caused by this exception falling outside of the except QCOPBaseError block to properly generate an exc.program_failure objects. https://github.com/mtzgroup/chemcloud-client/issues/46.