### PR TITLE
Updated repr to always include .success for ProgramOutputs and to sho…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [unreleased]
 
+### Changed
+
+- Added `threading.Lock()` to `capture_sys_stdout` so that it is thread safe.
+- Cached `XTBAdapter.program_version` result since calls to `importlib.metadata.version(...)` call `os.listdir()` and when doing very many `xtb` calls these became substantial (almost 1/2 the execution time). We have to use `importlib.metadata.version` rather than `xtb.__version__` directly because their `__version__` string is wrong.
+
 ## [0.7.3] - 2024-07-12
 
 ### Added

--- a/qcop/adapters/xtb.py
+++ b/qcop/adapters/xtb.py
@@ -20,6 +20,12 @@ from qcop.exceptions import (
 from .base import ProgramAdapter
 from .utils import capture_sys_stdout, set_env_variable
 
+# NOTE: Calls to importlib.metadata.version("xtb") are slow due to underlying calls to
+# os.listdir(), so we cache the version number here. This is necessary because the
+# __version__ string in xtb.__init__.py is wrong so we have to look this up dynamically
+# in the program_version method.
+CACHED_XTB_VERSION = None
+
 
 class XTBAdapter(ProgramAdapter[ProgramInput, SinglePointResults]):
     """Adapter for xtb-python."""
@@ -54,7 +60,12 @@ class XTBAdapter(ProgramAdapter[ProgramInput, SinglePointResults]):
         Returns:
             The program version.
         """
-        return importlib.metadata.version(self.program)
+        global CACHED_XTB_VERSION
+        if CACHED_XTB_VERSION:
+            return CACHED_XTB_VERSION
+        else:
+            CACHED_XTB_VERSION = importlib.metadata.version(self.program)
+            return CACHED_XTB_VERSION
 
     @staticmethod
     def _ensure_xtb():


### PR DESCRIPTION
…w this first. The last value in OptimizationResults.energies is nan if the last calulation failed.